### PR TITLE
fix "Create your first OROCOS controller" tutorial

### DIFF
--- a/docs/source/tutos/controller-tuto.rst
+++ b/docs/source/tutos/controller-tuto.rst
@@ -16,7 +16,8 @@ Generate the controller
     lwr_create_pkg my_controller -c MyController
     
     cd ~/catkin_ws
-    catkin config --init --extend ~/isir/lwr_ws/devel
+    chmod a+x ~/isir/lwr_ws/install/env.sh
+    catkin config --init --extend ~/isir/lwr_ws/install
 
 
 Build the controller


### PR DESCRIPTION
Newly created catkin ws for "my_controller" should be linked to the install directory of lwr_ws, but not devel directory.
Additionally, env.sh should be made executable for avoiding build errors.